### PR TITLE
feat: Display full timestamps in chat messages and history

### DIFF
--- a/script.js
+++ b/script.js
@@ -1663,7 +1663,7 @@ function createMessageHTML(message) {
         editedSpan.textContent = 'edited';
         timestampSpan.appendChild(editedSpan);
     }
-    timestampSpan.appendChild(document.createTextNode(new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })));
+    timestampSpan.appendChild(document.createTextNode(new Date(message.timestamp).toLocaleString([], { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true })));
     timestampDiv.appendChild(timestampSpan);
 
 
@@ -2316,7 +2316,7 @@ function showChatHistory() {
                 const messageTimestamp = new Date(lastMessage.timestamp).getTime();
                 if (messageTimestamp > 0) {
                     entry.timestamp = messageTimestamp;
-                    entry.date = new Date(messageTimestamp).toLocaleString();
+                    entry.date = new Date(messageTimestamp).toLocaleString([], { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true });
                 }
             }
         });


### PR DESCRIPTION
I've updated the timestamp formatting in the conversation UI to display the full date, month, year, and 12-hour time (e.g., "June 4, 2025 at 9:02 PM") instead of just the time.

Changes I made:
- Modified `createMessageHTML` in `script.js` to use `toLocaleString` with appropriate options for messages in the main chat view.
- Modified `showChatHistory` in `script.js` to use the same `toLocaleString` options for consistency in the chat history modal.

This ensures you can see the complete date and time for all messages, improving clarity when reviewing past conversations.